### PR TITLE
pom.xml: Add plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>crud-app</artifactId>
-    <version>0.5.5</version>
+    <version>0.5.6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -29,6 +29,19 @@
                 <version>3.0.0</version>
                 <configuration>
                     <mainClass>backend.DatabaseBackend</mainClass>
+                </configuration>
+            </plugin>
+            <!-- testing -->
+            <!-- in v2.22.2, a hanging process causes delay in execution -->
+            <!-- in v3.0.0-M6, when forkCount > 0, error "[SUREFIRE] std/in stream corrupted" is produced -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
+                <configuration>
+                    <forkCount>0</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <skipTests>false</skipTests>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Changes
- Made all of "JUnit-Jupiter" a dependency instead of select packages
- turned off javadoc warnings about uncommented attributes
- Added mvn-exec plugin, maven-compiler-plugin
- Added maven-surefire-plugin to automate testing